### PR TITLE
improved config init

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -1,17 +1,9 @@
 const std = @import("std");
 const Config = @This();
 
-bind_address: []const u8,
-port: u16,
-password: ?[]const u8,
-
-pub fn init() !Config {
-    return Config{
-        .bind_address = "127.0.0.1",
-        .port = 6383,
-        .password = null,
-    };
-}
+bind_address: []const u8 = "127.0.0.1",
+port: u16 = 6383,
+password: ?[]const u8 = null,
 
 pub fn load(allocator: std.mem.Allocator) !Config {
     const possible_paths = &[_][]const u8{
@@ -39,7 +31,7 @@ pub fn load(allocator: std.mem.Allocator) !Config {
     }
 
     std.log.warn("No configuration file found. Using defaults.", .{});
-    return init();
+    return .{};
 }
 
 fn fileExists(file_path: []const u8) bool {
@@ -48,7 +40,7 @@ fn fileExists(file_path: []const u8) bool {
 }
 
 pub fn loadFromFile(allocator: std.mem.Allocator, file_path: []const u8) !Config {
-    var config = try init();
+    var config = Config{};
 
     const file = std.fs.cwd().openFile(file_path, .{}) catch |err| {
         std.log.warn("Could not open config file '{s}': {s}. Using defaults.", .{ file_path, @errorName(err) });


### PR DESCRIPTION
I improved `config.zig` a little. Now you can init _some_ of the config params and rest leave in default. For example:

```diff
pub fn main() !void {
-   var config = try Config.init();
-   config.port = 3200;
-   something(config);
+   something(.{ .port = 3200 }); //rest will stay default
}
```

This change is also more Zig idiomatic.
